### PR TITLE
#419 provide missing argument 

### DIFF
--- a/SWEET/data/userdata.py
+++ b/SWEET/data/userdata.py
@@ -701,7 +701,7 @@ def get_schedule(day):
         return tgdate
 
 
-    for user in getAllUsers():
+    for user in getAllUsers(False):
         ud = UserData(user['userID'])
         ur = ud.reminders()
 


### PR DESCRIPTION
getAllUsers now has the missing argument provided. To test if this works, we'll need to release to staging and turn reminders  on through the staging site. If reminders are sent, it's fixed (also closing #418), if not hopefully Sentry will provide us with another error