### PR TITLE
fix for Submit responses button missing for MPS on Safari on Mac  #41…

### DIFF
--- a/SWEET/static/scripts/renderers/profiler.js
+++ b/SWEET/static/scripts/renderers/profiler.js
@@ -323,6 +323,10 @@ export function profilerModalRenderer(section) {
 }
 
 function isElementVisible(el) {
+    
+    // Edge case of element being null, return true
+    if(!el) return true
+
     var rect     = el.getBoundingClientRect(),
         vWidth   = window.innerWidth || document.documentElement.clientWidth,
         vHeight  = window.innerHeight || document.documentElement.clientHeight,


### PR DESCRIPTION
…7 and TypeError: undefined is not an object (evaluating 'el.getBoundingClientRect') #421